### PR TITLE
Add GitHub Issue Templates for Streamlined Issue Creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: "Bug Report"
+about: "Report a bug to help us improve."
+title: "[BUG] - <Short Description>"
+labels: bug, swoc
+assignees: ["@<username>"]
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps to reproduce the behavior:**
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Windows 10]
+- Browser [e.g. Chrome, Firefox]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Contributing Guidelines"
+    url: "https://github.com/KGupta2601/HackThisFall_InterestFusion/blob/main/CONTRIBUTING.md"
+    about: "Review our contributing guidelines before opening an issue."

--- a/.github/ISSUE_TEMPLATE/documentation_update.md
+++ b/.github/ISSUE_TEMPLATE/documentation_update.md
@@ -1,0 +1,16 @@
+---
+name: "Documentation Update"
+about: "Request updates or additions to the documentation."
+title: "[DOCS] - <Short Description>"
+labels: documentation, swoc
+assignees: ["@<username>"]
+---
+
+**What part of the documentation requires updating?**
+Provide a clear description of the section that needs updating or creating.
+
+**Why is this update necessary?**
+Explain the importance of the update.
+
+**Additional context**
+Add any other context, screenshots, or suggestions for the documentation update here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: "Feature Request"
+about: "Suggest an idea for this project."
+title: "[FEATURE] - <Short Description>"
+labels: enhancement, swoc
+assignees: ["@<username>"]
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,13 @@
+---
+name: "Other Issues"
+about: "For issues that don't fit into the other categories."
+title: "[OTHER] - <Short Description>"
+labels: swoc
+assignees: ["@<username>"]
+---
+
+**Describe your issue or suggestion**
+Provide a clear and concise description of the issue or idea.
+
+**Additional context**
+Add any other context, screenshots, or details related to your issue here.


### PR DESCRIPTION
This PR introduces GitHub issue templates to streamline issue creation in the repository. These templates provide predefined formats for reporting bugs, suggesting features, requesting documentation updates, and raising other types of issues. Additionally, a configuration file (config.yml) is added to customize the issue chooser and disable blank issues.

Fixes #11 