### PR TITLE
Prevent Upload of node_modules Directory in Pull Requests

### DIFF
--- a/.github/workflows/prevent-node-modules-upload.yml
+++ b/.github/workflows/prevent-node-modules-upload.yml
@@ -1,0 +1,22 @@
+name: Prevent Node Modules Upload
+
+on:
+  pull_request:
+    paths:
+      - '**/node_modules/**'
+
+jobs:
+  check_node_modules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Check for node_modules in Pull Request
+        run: |
+          if git diff --name-only origin/main | grep -q "node_modules/"; then
+            echo "🚨 The pull request contains 'node_modules/' directory, which is not allowed."
+            exit 1
+          else
+            echo "✅ No 'node_modules/' directory detected."
+          fi


### PR DESCRIPTION
# Pull Request Template

Description:
The repository currently does not have a safeguard to prevent contributors from accidentally uploading the node_modules directory in their pull requests. This can lead to unnecessary bloating of the repository and potential conflicts.

Issue Reference:
Closes https://github.com/KGupta2601/HackThisFall_InterestFusion/issues/59